### PR TITLE
Add timeout for pexpect instructions

### DIFF
--- a/asciinema_automation/cli.py
+++ b/asciinema_automation/cli.py
@@ -21,7 +21,8 @@ def cli():
                         help="time between each instructions")
     parser.add_argument('-sd', '--standart-deviation', type=int, default=60,
                         help="standart deviation for gaussian used to generate time between key strokes")
-
+    parser.add_argument('-t', '--timeout', type=int, default=30,
+                        help="timeout for a command output to come through")
     group = parser.add_mutually_exclusive_group()
     group.add_argument(
         '-d', '--debug',
@@ -43,6 +44,7 @@ def cli():
     asciinema_arguments = parser.parse_args().asciinema_arguments
     standart_deviation = parser.parse_args().standart_deviation
     loglevel = parser.parse_args().loglevel
+    timeout = parser.parse_args().timeout
 
     # Setup logger
     logfile = None
@@ -53,7 +55,7 @@ def cli():
 
     # Script
     script = Script(inputfile, outputfile, asciinema_arguments,
-                    wait, delay, standart_deviation)
+                    wait, delay, standart_deviation, timeout)
 
     #
     script.execute()

--- a/asciinema_automation/instruction.py
+++ b/asciinema_automation/instruction.py
@@ -33,14 +33,15 @@ class ChangeDelayInstruction(Instruction):
 
 
 class ExpectInstruction(Instruction):
-    def __init__(self, expect_value: str):
+    def __init__(self, expect_value: str, timeout: int):
         super().__init__()
         self.expect_value = expect_value
+        self.timeout = timeout
 
     def run(self, script):
         super().run(script)
         logging.debug("Expect %s", repr(self.expect_value))
-        script.process.expect(self.expect_value)
+        script.process.expect(self.expect_value, timeout=self.timeout)
 
 
 class SendInstruction(Instruction):

--- a/asciinema_automation/script.py
+++ b/asciinema_automation/script.py
@@ -27,7 +27,7 @@ def decode_escapes(s):
 
 class Script:
 
-    def __init__(self, inputfile: pathlib.Path, outputfile: pathlib.Path, asciinema_arguments: str, wait, delay, standart_deviation):
+    def __init__(self, inputfile: pathlib.Path, outputfile: pathlib.Path, asciinema_arguments: str, wait, delay, standart_deviation, timeout):
 
         # Set members from arguments
         self.inputfile = inputfile
@@ -108,7 +108,7 @@ class Script:
                 if expect_regex.search(line, 0) is not None:
                     expect_value = expect_regex.search(line, 0).group(1)
                     expect_value = decode_escapes(expect_value)
-                self.instructions.append(ExpectInstruction(expect_value))
+                self.instructions.append(ExpectInstruction(expect_value, timeout))
             elif line.startswith("#$ send"):
                 send_value = ""
                 if send_regex.search(line, 0) is not None:


### PR DESCRIPTION
Some commands might not return output within the default pexpect timeout (30s).

For me, anytime I try to run a script containing a command that needs to process a lot of things before outputing something, it results in a pexpect.TIMEOUT exception (you can try with e.g the command `nuclei`).

This PR adds a configurable `--timeout` argument to resolve this.