### PR TITLE
fix: More robustly escape input character

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,9 +4,12 @@ asciinema-automation
 .. image:: https://badge.fury.io/py/asciinema-automation.svg
     :target: https://badge.fury.io/py/asciinema-automation
 
+.. image:: https://github.com/PierreMarchand20/asciinema_automation/actions/workflows/CI.yml/badge.svg
+   :target: https://github.com/PierreMarchand20/asciinema_automation/actions/workflows/CI.yml
+   
 .. image:: https://img.shields.io/badge/code%20style-black-000000.svg
    :target: https://github.com/psf/black
-   
+
 Asciinema-Automation is a Python package which provides a small CLI utility to automate `asciinema <https://asciinema.org>`_ recordings. The only dependencies are asciinema and `Pexpect <https://pexpect.readthedocs.io/>`_.
 
 Example

--- a/asciinema_automation/instruction.py
+++ b/asciinema_automation/instruction.py
@@ -1,5 +1,6 @@
 import logging
 import random
+import re
 import time
 
 logger = logging.getLogger(__name__)
@@ -55,11 +56,7 @@ class SendInstruction(Instruction):
         self.receive_value = self.send_value
 
         # Check for special character
-        if "\\" in self.send_value:
-            self.receive_value = [
-                character if character != "\\" else character + "\\"
-                for character in list(self.send_value)
-            ]
+        self.receive_value = [re.escape(c) for c in list(self.send_value)]
 
         # Write intruction
         for send_character, receive_character in zip(

--- a/examples/special_character.sh
+++ b/examples/special_character.sh
@@ -1,0 +1,2 @@
+#$ sendcharacter #
+This is a test with URL (https://github.com)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "asciinema-automation"
-version = "0.1.2"
+version = "0.1.3"
 authors = [
   { name="Pierre Marchand", email="test@test.com" },
 ]

--- a/tests/reference_output/special_character.cast
+++ b/tests/reference_output/special_character.cast
@@ -1,0 +1,3 @@
+[?2004h$ #This is a test with URL (https://github.com)
+[?2004l[?2004h$ [?2004l
+exit


### PR DESCRIPTION
When using inputs that do have a meaning in RegExp, e.g
```shell
# This is a special comment (I want it to show in the clip!) pointing to an URL https//mysite.org?some=value&sort=true
```
the current code fails with reporting an invalid value.

This PR fixes the issue by consequently escaping input characters like brackets etc.