### PR TITLE
Improve the check for asciinema start when using --append

### DIFF
--- a/asciinema_automation/script.py
+++ b/asciinema_automation/script.py
@@ -151,7 +151,9 @@ class Script:
         self.process.expect("\n")
         logger.debug(self.process.before)
         if not (
-            "recording asciicast to " + str(self.outputfile) in str(self.process.before)
+            f"recording asciicast to {self.outputfile}" in str(self.process.before)
+            or f"appending to asciicast at {self.outputfile}"
+            in str(self.process.before)
         ):
             self.process.expect(pexpect.EOF)
             self.process.close()


### PR DESCRIPTION
Previously, we checked if the tool printed 'recording asciicast to <path>'. This text is only present when the output file is not present, or when an --overwrite flag was passed to asciinema. When the --append flag is used, a different message is printed by asciinema, and this commit checks for that.