### PR TITLE
Allow delays smaller than 50ms by setting delaybeforesend to None

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,7 +28,7 @@ jobs:
         - name: Run regression tests
           run: |
             set enable-bracketed-paste off
-            python3 -m pytest
+            python3 -m pytest -v
 
         - name: Check module imports with isort
           run: |

--- a/asciinema_automation/script.py
+++ b/asciinema_automation/script.py
@@ -51,6 +51,7 @@ class Script:
         delay,
         standard_deviation,
         timeout,
+        delaybeforesend=50 / 1000.0,
     ):
         # Set members from arguments
         self.inputfile = inputfile
@@ -59,6 +60,7 @@ class Script:
         self.delay = delay / 1000.0
         self.wait = wait / 1000.0
         self.standard_deviation = standard_deviation / 1000.0
+        self.delaybeforesend = delaybeforesend
 
         # Default values for data members
         self.expected = "\n"
@@ -147,6 +149,7 @@ class Script:
         )
         logger.info(spawn_command)
         self.process = pexpect.spawn(spawn_command, logfile=None)
+        self.process.delaybeforesend = self.delaybeforesend
 
         self.process.expect("\n")
         logger.debug(self.process.before)


### PR DESCRIPTION
Pexpect added[1] a default delay of 50ms before send, by default, to work around an issue with passwords being echod.  This makes it impossible to have delays smaller than this 50ms, currently.  This commit allows setting delaybeforesend to None, which is recommended by Pexpect to remove this additional delay hardcoded in Pexpect's code.

[1] - https://github.com/pexpect/pexpect/blob/master/pexpect/pty_spawn.py#L136-L150