### PR TITLE
fix: Expect spawn timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.2.1 - 2024-06-09
+
+### Fixed
+
+- Fix timeout issue in PR #16 thanks to @chrda81.
+
 ## 0.2.0 - 2023-12-25
 
 ### Added

--- a/asciinema_automation/cli.py
+++ b/asciinema_automation/cli.py
@@ -89,6 +89,7 @@ def cli(argv: Optional[List[str]] = None) -> None:
     script = Script(
         outputfile,
         asciinema_arguments,
+        timeout,
         wait / 1000,
         delay / 1000,
         standard_deviation / 1000,

--- a/asciinema_automation/script.py
+++ b/asciinema_automation/script.py
@@ -30,7 +30,7 @@ class Script:
         )
         logger.info(spawn_command)
         self.process = pexpect.spawn(spawn_command, timeout=self.timeout, logfile=None)
-        self.process.delaybeforesend = self.delaybeforesend  # type: ignore
+        self.process.delaybeforesend = self.delaybeforesend
 
         self.process.expect("\n")
         logger.debug(self.process.before)

--- a/asciinema_automation/script.py
+++ b/asciinema_automation/script.py
@@ -17,6 +17,7 @@ class Instruction:
 class Script:
     outputfile: pathlib.Path
     asciinema_arguments: str
+    timeout: float
     wait: float
     delay: float
     standard_deviation: float
@@ -28,7 +29,7 @@ class Script:
             "asciinema rec " + str(self.outputfile) + " " + self.asciinema_arguments
         )
         logger.info(spawn_command)
-        self.process = pexpect.spawn(spawn_command, logfile=None)
+        self.process = pexpect.spawn(spawn_command, timeout=self.timeout, logfile=None)
         self.process.delaybeforesend = self.delaybeforesend  # type: ignore
 
         self.process.expect("\n")


### PR DESCRIPTION
The spawn timeout of expect is triggered before the cli argument `timeout` is reached. This PR tries to fix that by using the timeout var which is used for instruction also for spawn.